### PR TITLE
docs(readme): use MatLog's GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ CatLog ![project unmaintained](https://img.shields.io/badge/project-unmaintained
 =========
 Graphical log reader for Android.
 
-_*Note*: this repo is unmaintained due to me having too little time and too little interest. Please check out a fork called [MatLog](https://plus.google.com/communities/108705871773878445106) that is optimized for newer devices._
+_*Note*: this repo is unmaintained due to me having too little time and too little interest. Please check out a fork called [MatLog](https://github.com/plusCubed/matlog) that is optimized for newer devices._
 
 Author
 --------


### PR DESCRIPTION
Easier to evaluate the differences. The G+ link is in their readme anyway.
